### PR TITLE
Rollback to check status code ok

### DIFF
--- a/Sources/GRPCClient/Streaming/ReceivableStreaming.swift
+++ b/Sources/GRPCClient/Streaming/ReceivableStreaming.swift
@@ -11,7 +11,7 @@ public extension ReceivableStreaming where Self: Streaming, Call: ReceivableCall
         do {
             try responseHandler(handler)
             try call.get().statusHandler { status in
-                if status != .ok {
+                if status.code != .ok {
                     handler(.failure(StreamingError(status)))
                 }
             }


### PR DESCRIPTION
最新のGRPCのコメント見たら、やはりcodeでチェックするのは正しいかもですね。
https://github.com/grpc/grpc-swift/blob/master/Sources/GRPC/GRPCStatus.swift#L44-L50